### PR TITLE
Allow to add empty string values and fix some typos

### DIFF
--- a/src/Zoho/CRM/Entities/Lead.php
+++ b/src/Zoho/CRM/Entities/Lead.php
@@ -106,11 +106,11 @@ class Lead extends Element
     public $Email;
 
     /**
-     * Secundary email address of the lead
+     * Secondary email address of the lead
      *
      * @var string
      */
-    public $Secundary_Email;
+    public $Secondary_Email;
 
     /**
      * Skype ID of the lead. Currently skype ID
@@ -161,7 +161,7 @@ class Lead extends Element
      *
      * @var string
      */
-    public $Campaing_Source;
+    public $Campaign_Source;
 
     /**
      * Street address of the lead

--- a/src/Zoho/CRM/ZohoClient.php
+++ b/src/Zoho/CRM/ZohoClient.php
@@ -523,7 +523,7 @@ class ZohoClient
         foreach ($properties as $property) {
             $propName = $property->getName();
             $propValue = $entity->$propName;
-            if (!empty($propValue)) {
+            if ($propValue !== null) {
                 $xml .= '<FL val="' . str_replace(['_', 'N36', 'E5F', '&', '98T'], [' ', '$', '_', 'and', '?'], $propName) . '"><![CDATA[' . $propValue . ']]></FL>';
             }
 


### PR DESCRIPTION
Few types were fixed.

Also added an ability to send an empty string to Zoho. It is required if you try to update the record in Zoho CRM, and you want to "clean" a field (to have it empty), by sending an empty string.