### PR TITLE
Delete multiple records support

### DIFF
--- a/src/Zoho/CRM/Request/Response.php
+++ b/src/Zoho/CRM/Request/Response.php
@@ -212,7 +212,8 @@ class Response
         elseif (isset($xml->result->message) && isset($xml->result->code)) {
             $this->message = (string) $xml->result->message;
             $this->code = (string) $xml->result->code;
-            # support deleteRecords with idList
+            # support deleteRecords with idList.
+            # EU DC has shorted record Ids, so matches 16 or more digits
             preg_match_all('/[0-9]{16,}/', $this->message, $matches);
             $this->recordId = implode(";",$matches[0]);
         } else {

--- a/src/Zoho/CRM/Request/Response.php
+++ b/src/Zoho/CRM/Request/Response.php
@@ -212,8 +212,9 @@ class Response
         elseif (isset($xml->result->message) && isset($xml->result->code)) {
             $this->message = (string) $xml->result->message;
             $this->code = (string) $xml->result->code;
-            preg_match('/[0-9]{18}/', $this->message, $matches);
-            $this->recordId = $matches[0];
+            # support deleteRecords with idList
+            preg_match_all('/[0-9]{16,}/', $this->message, $matches);
+            $this->recordId = implode(";",$matches[0]);
         } else {
             throw new ZohoCRMException('Unknown Zoho CRM response format.');
         }

--- a/src/Zoho/CRM/ZohoClient.php
+++ b/src/Zoho/CRM/ZohoClient.php
@@ -33,6 +33,13 @@ class ZohoClient
     const BASE_URI = 'https://crm.zoho.com/crm/private';
 
     /**
+     * URL for call request in zoho.eu
+     *
+     * @var string
+     */
+    const BASE_URI_EU = 'https://crm.zoho.eu/crm/private';
+
+    /**
      * Token used for session of request
      *
      * @var string
@@ -67,6 +74,12 @@ class ZohoClient
      */
     protected $module;
 
+    /** Base URI for selected domain
+     *
+     * @var string
+     */
+    protected $baseUri;
+
     /**
      * Construct
      *
@@ -81,7 +94,18 @@ class ZohoClient
         $this->format = 'xml';
         $this->client = $client ?: new HttpClient();
         $this->factory = $factory ?: new Factory();
+        $this->baseUri = self::BASE_URI;
         return $this;
+    }
+
+    /**
+     * Select EU Domain
+     *
+     * @param boolean isEU
+     */
+    public function setEuDomain($eu=true)
+    {
+        $this->baseUri = $eu? self::BASE_URI_EU : self::BASE_URI;
     }
 
     /**
@@ -443,7 +467,8 @@ class ZohoClient
     {
         if (empty($this->module)) {
             throw new \RuntimeException('Zoho CRM module is not set.');
-        }$parts = array(self::BASE_URI, $this->format, $this->module, $command);
+        }
+        $parts = array($this->baseUri, $this->format, $this->module, $command);
         return implode('/', $parts);
     }
 

--- a/src/Zoho/CRM/ZohoClient.php
+++ b/src/Zoho/CRM/ZohoClient.php
@@ -178,13 +178,18 @@ class ZohoClient
     /**
      * Implements deleteRecords API method.
      *
-     * @param string $id      Id of the record
+     * @param mixed $id  Id of the record if string or list of ids if an array
+     *                     a list will be passed as the parameter idlist
      *
      * @return Response The Response object
      */
     public function deleteRecords($id)
     {
-        $params['id'] = $id;
+        if (is_array($id)) {
+            $params['idlist'] = implode(';', $id);
+        } else {
+            $params['id'] = $id;
+        }
 
         return $this->call('deleteRecords', $params);
     }


### PR DESCRIPTION
Support deleteRecords when passed an array of record Ids (uses parameter idlist instead of id).
Parses deleteRecord response correctly for multiple records, recordId is set to semicolon separated list of record Ids.
Regex pattern for recordIds changed to [0-9]{16,} to support shorter record Ids seen on EU DC. Zoho support confirmed that they can be shorter. My experience is 16 or 17 digits.

